### PR TITLE
🐛  fix: entities with homeword equal null

### DIFF
--- a/src/pages/universe/[[...slug]].tsx
+++ b/src/pages/universe/[[...slug]].tsx
@@ -99,6 +99,8 @@ export const getStaticProps: GetStaticProps<Response> = async ({ params }) => {
     const urls = relationships.reduce((arr, key) => {
       const item = finded[key];
 
+      if (!item) return arr;
+
       const result = Array.isArray(item) ? item : [item];
 
       return [...arr, ...result];


### PR DESCRIPTION
some entities were been returned with homeworld prop equal null, generating an error when generateing the static page